### PR TITLE
Allow linking to workflow packages and vignettes/sections thereof

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(Biocannopkg)
 export(Biocexptpkg)
 export(Biocpkg)
+export(Biocworkpkg)
 export(CRANpkg)
 export(Githubpkg)
 export(Rpackage)

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -95,6 +95,12 @@ markdown <-
 #' Use \code{Biocpkg} for Bioconductor software, annotation and experiment data
 #' packages. The function automatically includes a link to the release landing
 #' page or if the package is only in devel, to the devel landing page.
+#'
+#' Use \code{Biocworkpkg} for Bioconductor workflow packages. This function
+#' automatically includes a link to the package landing page. If 
+#' \code{vignette} is specified, the function returns the address of the 
+#' compiled vignette document. If \code{section} is also specified, the
+#' address will include an anchor to the requested section of the vignette.
 #' 
 #' Use \code{CRANpkg} for R packages available on CRAN. The function
 #' automatically includes a link to the master CRAN landing page.
@@ -104,13 +110,19 @@ markdown <-
 #' If \code{package} is missing, the package name is assumed to be equal the
 #' repository name and is extracted from \code{repo}.
 #' 
-#' For R packages which are not available on Bioconductor, CRAN or GitHub use
+#' For R packages which are not available on Bioconductor, CRAN or GitHub, use
 #' \code{Rpackage}.
 #' 
 #' @param pkg character(1), package name
+#' @param vignette character(1), vignette name for workflows
+#' @param section character(1), section link for workflows
 #' @param repo Repository address in the format username/repo[/subdir]
 #' @return Markdown-formatted character vector containing a hyperlinked package
 #' name.
+#' 
+#' For \code{Biocworkpkg} with \code{vignette!=NULL}, an address to the 
+#' compiled vignette (optionally a specific section) is returned.
+#'
 #' @author Andrzej Oleś <andrzej.oles@@embl.de>, 2014-2015
 #' @examples
 #' 
@@ -118,12 +130,18 @@ markdown <-
 #' ## link to a Bioconductor package
 #' Biocpkg("IRanges")
 #' 
+#' ## link to a Bioconductor workflow
+#' Biocworkpkg("simpleSingleCell")
+#' Biocworkpkg("simpleSingleCell", vignette="work-0-intro")
+#' Biocworkpkg("simpleSingleCell", vignette="work-0-intro",
+#'     section="2_introduction")
+#'
 #' ## link to a CRAN package
 #' CRANpkg("data.table")
 #' 
 #' ## link to an R package on GitHub
 #' Githubpkg("rstudio/rmarkdown")
-#' 
+#'
 #' @name macros
 NULL
 
@@ -143,6 +161,30 @@ Biocannopkg <- function(pkg) {
 #' @export
 Biocexptpkg <- function(pkg) {
     Biocpkg(pkg)
+}
+
+#' @rdname macros
+#' @export
+Biocworkpkg <- function(pkg, vignette=NULL, section=NULL) {
+    mode <- if (is_devel()) "devel" else "release"
+
+    if (is.null(vignette)) {
+        url <- "[%s](http://bioconductor.org/packages/%s/workflows/html/%s.html)"
+        return(Rpackage(sprintf(url, pkg, mode, pkg)))
+    }
+
+    url <- sprintf("http://bioconductor.org/packages/%s/workflows/vignettes/%s/inst/doc/%s.html",
+        mode, pkg, vignette)
+    if (!is.null(section)) {
+        url <- paste0(url, "#", section)
+    }
+    return(url)
+}
+
+is_devel <- function() {
+    pkgver <- packageVersion("BiocStyle")
+    middle <- strsplit(as.character(pkgver), ".", fixed=TRUE)[[1]][2]
+    return(as.integer(middle)%%2==1L)
 }
 
 #' @rdname macros

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -93,8 +93,10 @@ markdown <-
 #' Markdown documents.
 #' 
 #' Use \code{Biocpkg} for Bioconductor software, annotation and experiment data
-#' packages. The function automatically includes a link to the release landing
-#' page or if the package is only in devel, to the devel landing page.
+#' packages. The function automatically includes a link to the package landing
+#' page, the version of which depends on the current Bioconductor version (i.e.
+#' if run in a devel environment, it will point towards the devel landing page;
+#' otherwise it will point to the release landing page).
 #'
 #' Use \code{Biocworkpkg} for Bioconductor workflow packages. This function
 #' automatically includes a link to the package landing page. If 
@@ -127,8 +129,14 @@ markdown <-
 #' @examples
 #' 
 #' 
-#' ## link to a Bioconductor package
+#' ## link to a Bioconductor software package
 #' Biocpkg("IRanges")
+#' 
+#' ## link to a Bioconductor annotation package
+#' Biocannopkg("org.Mm.eg.db")
+#'
+#' ## link to a Bioconductor experiment data package
+#' Biocexptpkg("affydata")
 #' 
 #' ## link to a Bioconductor workflow
 #' Biocworkpkg("simpleSingleCell")
@@ -148,33 +156,40 @@ NULL
 #' @rdname macros
 #' @export
 Biocpkg <- function(pkg) {
-    Rpackage( sprintf("[%s](http://bioconductor.org/packages/%s)", pkg, pkg) )
+    url <- "https://bioconductor.org/packages/%s/bioc/html/%s.html"
+    url <- sprintf(url, is_devel(), pkg) 
+    Rpackage( sprintf("[%s](%s)", pkg, url) )
 }
 
 #' @rdname macros
 #' @export
 Biocannopkg <- function(pkg) {
-    Biocpkg(pkg)
+    url <- "https://bioconductor.org/packages/%s/data/annotation/html/%s.html"
+    url <- sprintf(url, is_devel(), pkg) 
+    Rpackage( sprintf("[%s](%s)", pkg, url) )
 }
 
 #' @rdname macros
 #' @export
 Biocexptpkg <- function(pkg) {
-    Biocpkg(pkg)
+    url <- "https://bioconductor.org/packages/%s/data/experiment/html/%s.html"
+    url <- sprintf(url, is_devel(), pkg) 
+    Rpackage( sprintf("[%s](%s)", pkg, url) )
 }
 
 #' @rdname macros
 #' @export
 Biocworkpkg <- function(pkg, vignette=NULL, section=NULL) {
-    mode <- if (is_devel()) "devel" else "release"
+    mode <- is_devel()
 
     if (is.null(vignette)) {
-        url <- "[%s](http://bioconductor.org/packages/%s/workflows/html/%s.html)"
-        return(Rpackage(sprintf(url, pkg, mode, pkg)))
+        url <- "https://bioconductor.org/packages/%s/workflows/html/%s.html"
+        url <- sprintf(url, mode, pkg)
+        return(Rpackage( sprintf("[%s](%s)", pkg, url) ))
     }
 
-    url <- sprintf("http://bioconductor.org/packages/%s/workflows/vignettes/%s/inst/doc/%s.html",
-        mode, pkg, vignette)
+    url <- sprintf(file.path("https://bioconductor.org/packages/%s/workflows",
+        "vignettes/%s/inst/doc/%s.html"), mode, pkg, vignette)
     if (!is.null(section)) {
         url <- paste0(url, "#", section)
     }
@@ -184,7 +199,7 @@ Biocworkpkg <- function(pkg, vignette=NULL, section=NULL) {
 is_devel <- function() {
     pkgver <- packageVersion("BiocStyle")
     middle <- strsplit(as.character(pkgver), ".", fixed=TRUE)[[1]][2]
-    return(as.integer(middle)%%2==1L)
+    if (as.integer(middle)%%2==1L) "devel" else "release"
 }
 
 #' @rdname macros

--- a/man/macros.Rd
+++ b/man/macros.Rd
@@ -70,8 +70,20 @@ For R packages which are not available on Bioconductor, CRAN or GitHub, use
 \examples{
 
 
-## link to a Bioconductor package
+## link to a Bioconductor software package
 Biocpkg("IRanges")
+
+## link to a Bioconductor annotation package
+Biocannopkg("org.Mm.eg.db")
+
+## link to a Bioconductor experiment data package
+Biocexptpkg("affydata")
+
+## link to a Bioconductor workflow
+Biocworkpkg("simpleSingleCell")
+Biocworkpkg("simpleSingleCell", vignette="work-0-intro")
+Biocworkpkg("simpleSingleCell", vignette="work-0-intro",
+    section="2_introduction")
 
 ## link to a CRAN package
 CRANpkg("data.table")

--- a/man/macros.Rd
+++ b/man/macros.Rd
@@ -5,6 +5,7 @@
 \alias{Biocpkg}
 \alias{Biocannopkg}
 \alias{Biocexptpkg}
+\alias{Biocworkpkg}
 \alias{CRANpkg}
 \alias{Rpackage}
 \alias{Githubpkg}
@@ -16,6 +17,8 @@ Biocannopkg(pkg)
 
 Biocexptpkg(pkg)
 
+Biocworkpkg(pkg, vignette = NULL, section = NULL)
+
 CRANpkg(pkg)
 
 Rpackage(pkg)
@@ -25,11 +28,18 @@ Githubpkg(repo, pkg)
 \arguments{
 \item{pkg}{character(1), package name}
 
+\item{vignette}{character(1), vignette name for workflows}
+
+\item{section}{character(1), section link for workflows}
+
 \item{repo}{Repository address in the format username/repo[/subdir]}
 }
 \value{
 Markdown-formatted character vector containing a hyperlinked package
 name.
+
+For \code{Biocworkpkg} with \code{vignette!=NULL}, an address to the 
+compiled vignette (optionally a specific section) is returned.
 }
 \description{
 Functions for adding links to Bioconductor, CRAN and GitHub packages into R
@@ -40,6 +50,12 @@ Use \code{Biocpkg} for Bioconductor software, annotation and experiment data
 packages. The function automatically includes a link to the release landing
 page or if the package is only in devel, to the devel landing page.
 
+Use \code{Biocworkpkg} for Bioconductor workflow packages. This function
+automatically includes a link to the package landing page. If 
+\code{vignette} is specified, the function returns the address of the 
+compiled vignette document. If \code{section} is also specified, the
+address will include an anchor to the requested section of the vignette.
+
 Use \code{CRANpkg} for R packages available on CRAN. The function
 automatically includes a link to the master CRAN landing page.
 
@@ -48,7 +64,7 @@ should include the repository address in the format username/repo[/subdir].
 If \code{package} is missing, the package name is assumed to be equal the
 repository name and is extracted from \code{repo}.
 
-For R packages which are not available on Bioconductor, CRAN or GitHub use
+For R packages which are not available on Bioconductor, CRAN or GitHub, use
 \code{Rpackage}.
 }
 \examples{


### PR DESCRIPTION
Introduces a `Biocworkpkg` function that behaves like `Biocpkg` by default, but can also support linking to specific vignettes and specific sections of a vignette. In response to #46. 

I also took the liberty of modifying `Biocpkg` and friends so that they dynamically switch between release and devel based on the current version of _BiocStyle_.