### PR TITLE
Fix: pass `nomatch = 0`  to `match` function

### DIFF
--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -215,7 +215,7 @@ create_latex_template <- function(opts=NULL, sty=bioconductor.sty) {
   template_versions <- numeric_version(template_versions, strict = FALSE)
   template_versions <- sort(template_versions, decreasing = TRUE)
   
-  idx <- match(TRUE, version >= template_versions)
+  idx <- match(TRUE, version >= template_versions, nomatch = 0)
   
   template <- if (idx > 0) sprintf("default-%s.tex", template_versions[idx]) else "default.tex"
   


### PR DESCRIPTION
In line [218 of `pdf_document.R`](https://github.com/Bioconductor/BiocStyle/blob/master/R/pdf_document.R#L218), the default no-match value `NA` raises following error:

```
Error in if (idx > 0) sprintf("default-%s.tex", template_versions[idx]) else "default.tex" :
  missing value where TRUE/FALSE needed
```