### PR TITLE
fixed figure caption titles with inword dot

### DIFF
--- a/R/html_document.R
+++ b/R/html_document.R
@@ -217,7 +217,7 @@ caption_titles = function(lines) {
   lines = gsub(regex, '\\1<span class="caption-title">\\2</span><br>', lines, perl=TRUE)
   
   # figures: match to figure labels preceded by '<p class="caption'
-  regex = '(\\(#fig:[-/[:alnum:]]+\\))[[:space:]]*([^.]+).?'
+  regex = '(\\(#fig:[-/[:alnum:]]+\\))(.*?)((\\.[[:space:]])|(\\.$)|($)).?'
   idx =  which(grepl(regex, lines))
   idx = idx[vapply(idx, function(i) any(grepl('^<p class="caption', lines[i-0:1])), logical(1L))]
   lines[idx] = gsub(regex, '\\1<span class="caption-title">\\2</span><br>', lines[idx])

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -213,11 +213,11 @@ create_html_template <- function() {
 
 caption_titles = function(lines) {
   # tables: match to <caption>...</caption> lines
-  regex = '(?<=^<caption>)[[:space:]]*(\\(#tab:[-/[:alnum:]]+\\))?[[:space:]]*([^.]+).?'
+  regex = '(?<=^<caption>)[[:space:]]*(\\(#tab:[-/[:alnum:]]+\\))(.*?)((\\.[[:space:]])|(\\.$)|($))'
   lines = gsub(regex, '\\1<span class="caption-title">\\2</span><br>', lines, perl=TRUE)
   
   # figures: match to figure labels preceded by '<p class="caption'
-  regex = '(\\(#fig:[-/[:alnum:]]+\\))(.*?)((\\.[[:space:]])|(\\.$)|($)).?'
+  regex = '(\\(#fig:[-/[:alnum:]]+\\))(.*?)((\\.[[:space:]])|(\\.$)|($))'
   idx =  which(grepl(regex, lines))
   idx = idx[vapply(idx, function(i) any(grepl('^<p class="caption', lines[i-0:1])), logical(1L))]
   lines[idx] = gsub(regex, '\\1<span class="caption-title">\\2</span><br>', lines[idx])


### PR DESCRIPTION
figure titles are now extracted by looking for the first occurance of ". ", ".(endofline)" or "(endofline)"

This fixes #61