### PR TITLE
Updating footnote finding regex

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.15.6
+Version: 2.15.7
 Author: Andrzej Oleś, Martin Morgan, Wolfgang Huber
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 Imports: bookdown, knitr (>= 1.12), rmarkdown (>= 1.2), stats, utils, yaml,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.15.7
+Version: 2.15.8
 Author: Andrzej Oleś, Martin Morgan, Wolfgang Huber
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 Imports: bookdown, knitr (>= 1.12), rmarkdown (>= 1.2), stats, utils, yaml,

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -239,11 +239,11 @@ process_footnotes = function(lines) {
   j = min(j[j > i])
   
   ## extract footnotes and their ids
-  r = sprintf('<li id="%s([0-9]+)"><p>(.+)<a href="#%sref\\1"([^>]*)>.</a></p></li>', fn_label, fn_label)
-  s = paste(lines[i:j], collapse = '\n')
-  fns = unlist(regmatches(s, gregexpr(r, s)))
-  ids = as.integer(gsub(r, '\\1', fns))
-  fns = gsub(r, '\\2', fns)
+  regex = sprintf('<li id="%s([0-9]+)"><p>(.+)<a href="#%sref\\1"([^>]*)>.{1,2}</a></p></li>', fn_label, fn_label)
+  footnote_lines = paste(lines[i:j], collapse = '\n')
+  fns = unlist(regmatches(footnote_lines, gregexpr(regex, footnote_lines)))
+  ids = as.integer(gsub(regex, '\\1', fns))
+  fns = gsub(regex, '\\2', fns)
   
   # remove footnotes at the bottom
   lines = lines[-(i:j)]


### PR DESCRIPTION
I've run into an issue where footnotes are not handled correctly when converting the pandoc HTML to the final version.

This only occurs on a system running RStudio 1.3.869 and is fine on a separate computer using RStudio 1.2.5033.  I suspect the change in pandoc versions (2.7.3 vs 2.3.1) is the culprit but I can't find any release notes detailing this and there's many other difference between the two computers.

The cause seems to be because the 'left facing arrow with hook' pandoc inserts into the footnote link now includes some additional hidden bytes, that aren't matched by the regular expression that moves the footnotes.

On my working system I get get:

```r
> charToRaw('↩')
[1] e2 86 a9
```

and on the system where it is failing I see:

```r
> charToRaw('↩︎')
[1] e2 86 a9 ef b8 8e
```

This patch just expands the regular expression to allow for one or two character, which seems sufficient to match the new version but should be backwards compatible if this is a quirk of my machine.

---

I also updated some variable names as I couldn't use a variable called `s` inside RStudio debugging!