### PR TITLE
Patch issue with out.width for smallfigure and widefigure environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.19.0
+Version: 2.19.1
 Author: Andrzej Oleś, Martin Morgan, Wolfgang Huber
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 Imports: bookdown, knitr (>= 1.30), rmarkdown (>= 1.2), stats, utils, yaml,

--- a/R/knitr_options.R
+++ b/R/knitr_options.R
@@ -48,10 +48,6 @@
         options$fig.height = options$fig.width * options$fig.asp
     }
     
-    # re-evaluate code from knitr:::fix_options which is called before the hook
-    #if ( !is.null(options$out.width) && is.na(options$out.width) )
-    #  options$out.width = "100%"
-    
     if(is.null(options$out.width) && grepl(x = options$fig.env, pattern = "*figure*"))
       options$out.width = "100%" 
     

--- a/R/knitr_options.R
+++ b/R/knitr_options.R
@@ -49,8 +49,11 @@
     }
     
     # re-evaluate code from knitr:::fix_options which is called before the hook
-    if ( !is.null(options$out.width) && is.na(options$out.width) )
-      options$out.width = "100%"
+    #if ( !is.null(options$out.width) && is.na(options$out.width) )
+    #  options$out.width = "100%"
+    
+    if(is.null(options$out.width) && grepl(x = options$fig.env, pattern = "*figure*"))
+      options$out.width = "100%" 
     
     options
   },

--- a/inst/unitTests/test_figure_options.R
+++ b/inst/unitTests/test_figure_options.R
@@ -1,0 +1,26 @@
+test_default_figure_options <- function() {
+    filename <- rmarkdown::draft(tempfile(fileext = ".Rmd"), edit = FALSE,
+                                 template="html_document", package = "BiocStyle")
+    output_file <- tempfile(fileext = ".html")
+    rmarkdown::render(filename, output_file = output_file, quiet = TRUE)
+
+    ## with default options, we expect all three figures to have out.width = "100%"
+    html <- BiocStyle:::readUTF8(output_file)
+    checkTrue(length( grep(pattern = 'width="100%"', x = html) ) == 3L)
+    file.remove(output_file)
+    
+    ## modify the small figure to have a define out.width and check it's respected
+    lines <- BiocStyle:::readUTF8(filename)
+    lines <- gsub(x = lines, pattern = "fig.small=TRUE", 
+                  replacement = 'fig.small=TRUE, out.width="500px"')
+    BiocStyle:::writeUTF8(lines, filename)
+    rmarkdown::render(filename, output_file = output_file, quiet = TRUE)
+    html <- BiocStyle:::readUTF8(output_file)
+    checkTrue(length( grep(pattern = 'width="100%"', x = html) ) == 2L)
+    checkTrue(length( grep(pattern = 'width="500px"', x = html) ) == 1L)
+    file.remove(output_file)
+    
+    file.remove(filename)
+}
+
+

--- a/vignettes/AuthoringRmdVignettes.Rmd
+++ b/vignettes/AuthoringRmdVignettes.Rmd
@@ -241,7 +241,7 @@ produce Figure \@ref(fig:plot).
     plot(cars)
     ```
 
-```{r plot, fig.cap="Regular figure. The first sentence of the figure caption is automatically emphasized to serve as figure title.", echo=FALSE, out.width="500px"}
+```{r plot, fig.cap="Regular figure. The first sentence of the figure caption is automatically emphasized to serve as figure title.", echo=FALSE}
 plot(cars)
 ```
 

--- a/vignettes/AuthoringRmdVignettes.Rmd
+++ b/vignettes/AuthoringRmdVignettes.Rmd
@@ -241,7 +241,7 @@ produce Figure \@ref(fig:plot).
     plot(cars)
     ```
 
-```{r plot, fig.cap="Regular figure. The first sentence of the figure caption is automatically emphasized to serve as figure title.", echo=FALSE}
+```{r plot, fig.cap="Regular figure. The first sentence of the figure caption is automatically emphasized to serve as figure title.", echo=FALSE, out.width="500px"}
 plot(cars)
 ```
 


### PR DESCRIPTION
This addresses #83 

I think the move of `knitr:::fix_options()` to after the hooks have been run, rather than before, has affected how the `out.width` parameter is set.  I don't know why the new defaults make the figure disappear, the resulting image still has a width in the output HTML, but my understanding of the code is that we want this to be "100%" unless the user explicitly defines it in the chunk options.

This patch tries to achieve that, and includes some new unit tests to check that correct width attribute is assigned in the output HTML file.