### PR TITLE
Maintain code block background colour

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.19.1
+Version: 2.19.2
 Author: Andrzej Oleś, Martin Morgan, Wolfgang Huber
 Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 Imports: bookdown, knitr (>= 1.30), rmarkdown (>= 1.2), stats, utils, yaml,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,14 +5,15 @@ Description: Provides standard formatting styles for Bioconductor PDF
     functionality.
 Version: 2.19.2
 Authors@R: c(
-        person("Andrzej", "Oleś", role = "aut"), 
+        person("Andrzej", "Oleś", role = "aut",
+            comment = c(ORCID = "0000-0003-0285-2787")), 
         person("Mike", "Smith", role = "ctb",
             comment = c(ORCID = "0000-0002-7800-3848")
         ),
         person("Martin", "Morgan", role = "ctb"),
         person("Wolfgang", "Huber", role = "ctb"),
-        person("Bioconductor Package", role = "Maintainer", 
-            email = "maintainer@bioconductor.org", role = "cre")
+        person("Bioconductor Package", role = "cre",
+            email = "maintainer@bioconductor.org")
         )
 Imports: bookdown, knitr (>= 1.30), rmarkdown (>= 1.2), stats, utils, yaml,
     BiocManager

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,16 @@ Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
 Version: 2.19.2
-Author: Andrzej Oleś, Martin Morgan, Wolfgang Huber
-Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
+Authors@R: c(
+        person("Andrzej", "Oleś", role = "aut"), 
+        person("Mike", "Smith", role = "ctb",
+            comment = c(ORCID = "0000-0002-7800-3848")
+        ),
+        person("Martin", "Morgan", role = "ctb"),
+        person("Wolfgang", "Huber", role = "ctb"),
+        person("Bioconductor Package", role = "Maintainer", 
+            email = "maintainer@bioconductor.org", role = "cre")
+        )
 Imports: bookdown, knitr (>= 1.30), rmarkdown (>= 1.2), stats, utils, yaml,
     BiocManager
 Suggests: BiocGenerics, RUnit, htmltools

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,18 @@
+CHANGES IN VERSION 2.20.0
+------------------------
+
+    o Addressed styling issues for output code blocks, introduced by changes
+    in rmarkdown version 2.7.0 
+    (https://github.com/Bioconductor/BiocStyle/issues/86)
+
 CHANGES IN VERSION 2.18.0
 ------------------------
 
 BUG FIXES
 
     o Fix issue where images created with the `fig.small=TRUE` chunk argument
-    were not displayed in HTML output.
+    were not displayed in HTML output 
+    (https://github.com/Bioconductor/BiocStyle/issues/83).
 
 CHANGES IN VERSION 2.8.0
 ------------------------

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -77,6 +77,9 @@ html_document <- function(toc = TRUE,
     ## wrap tables in a container
     x = process_tables(x)
     
+    ## remove css that hardcodes <pre> tag styling
+    x = modify_css(x)
+    
     writeUTF8(x, output)
     output
   }
@@ -99,7 +102,7 @@ html_document <- function(toc = TRUE,
   # per-section numbering of figures/tables
   
   number_sections_override <- number_sections
-  
+
   base_format <- function(..., number_sections) {
     rmarkdown::html_document(..., number_sections = number_sections_override)
   }
@@ -290,5 +293,12 @@ process_footnotes = function(lines) {
 process_tables = function(lines) {
   lines = gsub("<table", "<div class='horizontal-scroll'><table", lines, fixed = TRUE)
   lines = gsub("</table>", "</table></div>", lines, fixed = TRUE)
+  lines
+}
+
+modify_css = function(lines) {
+  ## Since rmarkdown v 2.7.0 the CSS below gets injected during HTML creation, 
+  ## rather than being taken from the template.html. We remove it again here.
+  lines = gsub("       pre:not([class]) { background-color: white }", "", lines, fixed = TRUE)
   lines
 }

--- a/vignettes/AuthoringRmdVignettes.Rmd
+++ b/vignettes/AuthoringRmdVignettes.Rmd
@@ -23,8 +23,8 @@ vignette: |
 
 # Prerequisites
 
-_Bioconductor_ R Markdown format is build on top of _R_ package `r
-CRANpkg("bookdown")`, which in turn relies on `r CRANpkg("rmarkdown")` and
+_Bioconductor_ R Markdown format is build on top of _R_ package 
+`r CRANpkg("bookdown")`, which in turn relies on `r CRANpkg("rmarkdown")` and
 [pandoc](http://johnmacfarlane.net/pandoc/) to compile the final output
 document. Therefore, unless you are using RStudio, you will need a recent
 version of [pandoc](http://johnmacfarlane.net/pandoc/) (>= 1.17.2). See the


### PR DESCRIPTION
This primarily tries to fix the code block styling in #86 

**rmarkdown** now injects `pre:not([class]) { background-color: white; }` into the HTML head at https://github.com/rstudio/rmarkdown/blob/9c1498806fef286f3891238a8298e064969c8aec/R/html_dependencies.R#L78

Previously this was found in the HTML page template, and we removed it there.  Now we have to remove it later.

---

I also added myself as a contributor in the `DESCRIPTION` file and changed to the `Author@R` format so I could include the ORCID.  Feel free to ignore that commit if you don't agree.