### PR TITLE
Issue with longtable patch and recent TexLive distributions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.23.0
+Version: 2.23.1
 Authors@R: c(
         person("Andrzej", "Oleś", role = "aut",
             comment = c(ORCID = "0000-0003-0285-2787")

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+CHANGES IN VERSION 2.24.0
+------------------------
+
+BUG FIXES
+
+    o Fixed incompatibility with recent versions of the longtable latex package
+    when producing a PDF vignette.  This bug manifested with the message
+    'LaTeX Error: Missing \begin{document}.' when attempting to knit.
+    (https://github.com/Bioconductor/BiocStyle/issues/89)
+
+
 CHANGES IN VERSION 2.22.0
 ------------------------
 

--- a/inst/resources/tex/Bioconductor.sty
+++ b/inst/resources/tex/Bioconductor.sty
@@ -548,12 +548,13 @@
 \makeatother
 %
 % apply longtable patch from http://www.latex-project.org/cgi-bin/ltxbugs2html?pr=tools/3512
+% This now appears to be included in longtable directly and is only needed for older versions
 %
 \makeatletter
 \@ifpackageloaded{longtable}{
-%\@ifpackagelater{<name>}{<date>}{<yes>}{<no>}
+% Usage \@ifpackagelater{<name>}{<date>}{<yes>}{<no>}
   \@ifpackagelater{longtable}{2020/01/07}{
-    {\wlog{Skipping patch longtable}}
+    {\wlog{Skipping longtable patch}}
   }{
     \patchcmd{\LT@start}{\advance\vsize}{\global\advance\vsize}
       {\wlog{Patching longtable .}}{Cannot patch longtable \LT@start}

--- a/inst/resources/tex/Bioconductor.sty
+++ b/inst/resources/tex/Bioconductor.sty
@@ -551,45 +551,50 @@
 %
 \makeatletter
 \@ifpackageloaded{longtable}{
-\patchcmd{\LT@start}{\advance\vsize}{\global\advance\vsize}
-  {\wlog{Patching longtable .}}{Cannot patch longtable \LT@start}
-\patchcmd{\endlongtable}{\endgraf\penalty -\LT@end@pen}{\endgraf\penalty -\LT@end@pen
-  \ifvoid\LT@foot\else
-    \global\advance\vsize\ht\LT@foot
-    \global\advance\@colroom\ht\LT@foot
-    \dimen@\pagegoal\advance\dimen@\ht\LT@foot\pagegoal\dimen@
-  \fi}
-  {\wlog{Patching longtable ..}}{Cannot patch longtable \endlongtable}
-\patchcmd{\endlongtable}{\pagegoal\vsize}{}
-  {\wlog{Patching longtable ...}}{Cannot patch longtable \endlongtable}
-\def\LT@output{%
-  \ifnum\outputpenalty <-\@Mi
-    \ifnum\outputpenalty > -\LT@end@pen
-      \LT@err{floats and marginpars not allowed in a longtable}\@ehc
-    \else
-      \setbox\z@\vbox{\unvbox\@cclv}%
-      \ifdim \ht\LT@lastfoot>\ht\LT@foot
-        \dimen@\pagegoal
-        \advance\dimen@\ht\LT@foot
-        \advance\dimen@-\ht\LT@lastfoot
-        \ifdim\dimen@<\ht\z@
-          \setbox\@cclv\vbox{\unvbox\z@\copy\LT@foot\vss}%
-          \@makecol
-          \@outputpage
-          \global\vsize\@colroom
-          \setbox\z@\vbox{\box\LT@head}%
+%\@ifpackagelater{<name>}{<date>}{<yes>}{<no>}
+  \@ifpackagelater{longtable}{2020/01/07}{
+    {\wlog{Skipping patch longtable}}
+  }{
+    \patchcmd{\LT@start}{\advance\vsize}{\global\advance\vsize}
+      {\wlog{Patching longtable .}}{Cannot patch longtable \LT@start}
+    \patchcmd{\endlongtable}{\endgraf\penalty -\LT@end@pen}{\endgraf\penalty -\LT@end@pen
+      \ifvoid\LT@foot\else
+        \global\advance\vsize\ht\LT@foot
+        \global\advance\@colroom\ht\LT@foot
+        \dimen@\pagegoal\advance\dimen@\ht\LT@foot\pagegoal\dimen@
+      \fi}
+      {\wlog{Patching longtable ..}}{Cannot patch longtable \endlongtable}
+    \patchcmd{\endlongtable}{\pagegoal\vsize}{}
+      {\wlog{Patching longtable ...}}{Cannot patch longtable \endlongtable}
+    \def\LT@output{%
+      \ifnum\outputpenalty <-\@Mi
+        \ifnum\outputpenalty > -\LT@end@pen
+          \LT@err{floats and marginpars not allowed in a longtable}\@ehc
+        \else
+          \setbox\z@\vbox{\unvbox\@cclv}%
+          \ifdim \ht\LT@lastfoot>\ht\LT@foot
+            \dimen@\pagegoal
+            \advance\dimen@\ht\LT@foot
+            \advance\dimen@-\ht\LT@lastfoot
+            \ifdim\dimen@<\ht\z@
+              \setbox\@cclv\vbox{\unvbox\z@\copy\LT@foot\vss}%
+              \@makecol
+              \@outputpage
+              \global\vsize\@colroom
+              \setbox\z@\vbox{\box\LT@head}%
+            \fi
+          \fi
+          \unvbox\z@\ifvoid\LT@lastfoot\copy\LT@foot\else\box\LT@lastfoot\fi
         \fi
-      \fi
-      \unvbox\z@\ifvoid\LT@lastfoot\copy\LT@foot\else\box\LT@lastfoot\fi
-    \fi
-  \else
-    \setbox\@cclv\vbox{\unvbox\@cclv\copy\LT@foot\vss}%
-    \@makecol
-    \@outputpage
-      \global\vsize\@colroom
-    \copy\LT@head\nobreak
-  \fi}
-\wlog{Patching longtable done!}
+      \else
+        \setbox\@cclv\vbox{\unvbox\@cclv\copy\LT@foot\vss}%
+        \@makecol
+        \@outputpage
+          \global\vsize\@colroom
+        \copy\LT@head\nobreak
+      \fi}
+    \wlog{Patching longtable done!}
+  }
 }{}
 %
 %


### PR DESCRIPTION
This patch tries to address #89 

I think the current code below tries to address issues where a float and a longtable on the same page would cause content to be rendered off the page. 
 https://github.com/Bioconductor/BiocStyle/blob/0d7515b137239b784f2061425b4c1a541745b7c0/inst/resources/tex/Bioconductor.sty#L550-L595

This patch in the sty file seems to have some incompatibility with **longtable** v4.17 which is distributed with TexLive 2021 and produces the error seen in #89.

I've found it pretty hard to track down specific version changes for **longtable** but v4.13 2020-01-07 (https://github.com/latex3/latex2e/blob/develop/required/tools/longtable-2020-01-07.sty) seems to have to have all the patch code already applied. That version ships with my Ubuntu 20.04 LTS / TexLive 2019 setup and I think makes the patch in our .sty file redundant for "current" systems

Give that, this change ensures the patch is only applied if **longtable** is older than v4.13.  This seems to have no effect on PDFs produced with **longtable** v4.13 and allows documents to be successfully created when using **longtable** v4.17.  Of course I may not have tested the specific problem scenario the original patch addressed, but I've tried various combinations of large tables, figures and text without seeing an issue.