### PR TITLE
update css to fix table captions

### DIFF
--- a/inst/resources/html/bioconductor.css
+++ b/inst/resources/html/bioconductor.css
@@ -229,7 +229,8 @@ p.caption {
 caption {
   padding: 0px;
   margin-bottom: 10px;
-  min-width: 583;
+  min-width: 583px;
+  text-align: justify;
 }
 span.caption-title {
   color: #1a81c2;


### PR DESCRIPTION
The min-width property is missing px in the specification and text should be justified to match figure captions – these changes make the display of tables more consistent in Rmd vignettes.