### PR TITLE
address issue with Glimma plots not appearing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Standard styles for vignettes and other Bioconductor documents
 Description: Provides standard formatting styles for Bioconductor PDF
     and HTML documents. Package vignettes illustrate use and
     functionality.
-Version: 2.25.0
+Version: 2.25.1
 Authors@R: c(
         person("Andrzej", "Oleś", role = "aut",
             comment = c(ORCID = "0000-0003-0285-2787")

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+CHANGES IN VERSION 2.26.0
+------------------------
+
+BUG FIXES
+
+    o BiocStyle no longer breaks Javascript inserted by the Glimma package to
+    produce interactive plots.
+    (https://github.com/Bioconductor/BiocStyle/issues/97)
+
 CHANGES IN VERSION 2.24.0
 ------------------------
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -294,8 +294,14 @@ process_footnotes = function(lines) {
 ## We wrap tables in a <div> so they can fill the screen on mobile
 ## but also scroll if they overflow horizontally
 process_tables = function(lines) {
-  lines = gsub("<table", "<div class='horizontal-scroll'><table", lines, fixed = TRUE)
-  lines = gsub("</table>", "</table></div>", lines, fixed = TRUE)
+    
+  ## this will inadvertantly mess up some javascript e.g. from Glimma
+  ## so we only modify the body of the html
+  body_start = grep(pattern = "<body>", x = lines, fixed = TRUE)
+  body_end = grep(pattern = "</body>", x = lines, fixed = TRUE)
+    
+  lines[body_start:body_start] = gsub("<table", "<div class='horizontal-scroll'><table", lines[body_start:body_start], fixed = TRUE)
+  lines[body_start:body_start] = gsub("</table>", "</table></div>", lines[body_start:body_start], fixed = TRUE)
   lines
 }
 

--- a/R/html_document.R
+++ b/R/html_document.R
@@ -295,13 +295,13 @@ process_footnotes = function(lines) {
 ## but also scroll if they overflow horizontally
 process_tables = function(lines) {
     
-  ## this will inadvertantly mess up some javascript e.g. from Glimma
+  ## this will inadvertently mess up some javascript e.g. from Glimma
   ## so we only modify the body of the html
   body_start = grep(pattern = "<body>", x = lines, fixed = TRUE)
   body_end = grep(pattern = "</body>", x = lines, fixed = TRUE)
     
-  lines[body_start:body_start] = gsub("<table", "<div class='horizontal-scroll'><table", lines[body_start:body_start], fixed = TRUE)
-  lines[body_start:body_start] = gsub("</table>", "</table></div>", lines[body_start:body_start], fixed = TRUE)
+  lines[body_start:body_end] = gsub("<table", "<div class='horizontal-scroll'><table", lines[body_start:body_end], fixed = TRUE)
+  lines[body_start:body_end] = gsub("</table>", "</table></div>", lines[body_start:body_end], fixed = TRUE)
   lines
 }
 


### PR DESCRIPTION
This addresses #97 

The issue is that the `process_tables()` function adds the tag `<div class='horizontal-scroll'>` before any instances of `<table>`.  This inadvertantly breaks the Javascript that **Glimma** inserts into the page, by including some unexpected quotes.  Even if we change the quote type, adding this extra div is almost certainly not correct.

This patch means the additional div is only inserted around `<table>` tags that are part of the HTML body and not in the head.  