### PR TITLE
Fix BiocStyle & pkgdown interaction

### DIFF
--- a/R/pdf_document.R
+++ b/R/pdf_document.R
@@ -80,12 +80,14 @@ pdf_document <- function(toc = TRUE,
   
   ## code chunks and code highlighting
   thm <- system.file("themes", "default.css", package = "BiocStyle")
-  opts_knit$set(out.format="latex");
+  out_fmt <- opts_knit$get("out.format")
+  opts_knit$set(out.format="latex")
   head = c(head,
            "% code highlighting",
            knit_theme$get(thm)$highlight,
            readLines(file.path(resources, "tex", "highlighting-macros.def")))
-  
+  opts_knit$set(out.format=out_fmt)
+
   if (use_unsrturl)
     head = c(head, sprintf("\\AtBeginDocument{\\bibliographystyle{%s}}\n",  sub(".bst$", "", template_files[["bst"]])))
   

--- a/inst/unitTests/test_pdf_document.R
+++ b/inst/unitTests/test_pdf_document.R
@@ -2,9 +2,27 @@ test_pdf_document <- function() {
   filename <- rmarkdown::draft(tempfile(fileext = ".Rmd"), edit = FALSE,
                                template="pdf_document", package = "BiocStyle")
   lines <- BiocStyle:::readUTF8(filename)
-  lines <- BiocStyle:::modifyLines(lines, from = "title:", replace = FALSE, 
+  lines <- BiocStyle:::modifyLines(lines, from = "title:", replace = FALSE,
                        insert='subtitle: "Vignette Subtitle"')
   BiocStyle:::writeUTF8(lines, filename)
   rmarkdown::render(filename)
   unlink(filename)
+}
+
+test_pdf_document_restores_out_format <- function() {
+  ## Regression test for https://github.com/Bioconductor/BiocStyle/pull/108
+  ##
+  ## BiocStyle::pdf_document() temporarily sets the global knitr option
+  ## 'out.format' to "latex" in order to look up the syntax highlighting
+  ## theme, but used to leave it set afterwards. This corrupted the knitr
+  ## state for anything rendered later in the same R session, e.g. pkgdown
+  ## building several articles (one of which uses BiocStyle::pdf_document)
+  ## within a single process, which itself relies on 'out.format' being
+  ## "html".
+  out_format_before <- knitr::opts_knit$get("out.format")
+  on.exit(knitr::opts_knit$set(out.format = out_format_before))
+
+  knitr::opts_knit$set(out.format = "html")
+  invisible(BiocStyle::pdf_document())
+  checkIdentical(knitr::opts_knit$get("out.format"), "html")
 }


### PR DESCRIPTION
pkgdown https://pkgdown.r-lib.org/ is an R package to build static websites from package documentation and vignettes.

pkgdown evaluates the output format of the vignettes, but it does not use it, since it generates html documents.

However, BiocStyle manually sets the out.format to "latex". This makes pkgdown generate an html file that then is passed to pdflatex, giving an error "\begin{document}" not found.  The temporary .tex file contains an html version of the vignette.

![imatge](https://github.com/Bioconductor/BiocStyle/assets/75441/ccd96533-5e84-4040-81f3-aeb96f90812e)


It seems the only reason BiocStyle sets "out.format" to "latex" is to call `knit_theme$get(thm)$highlight`, by setting "out.format" to its former value everything seems to keep working.

This change restores `"out.format"`, so pkgdown is still able to generate the html files. pdf vignettes still work as expected.
