### PR TITLE
Fix counter needed in pandoc 3.8.2 and later

### DIFF
--- a/inst/rmd/latex/default-2.8.tex
+++ b/inst/rmd/latex/default-2.8.tex
@@ -278,6 +278,7 @@ $if(csl-refs)$
 \newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
+\newcounter{none} % pandoc 3.8.1 and later uses a counter for unnamed tables.
 
 $for(header-includes)$
 $header-includes$
@@ -331,6 +332,7 @@ $if(biblatex)$
 \printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
 
 $endif$
+
 $for(include-after)$
 $include-after$
 

--- a/inst/unitTests/test_pdf_document.R
+++ b/inst/unitTests/test_pdf_document.R
@@ -2,9 +2,42 @@ test_pdf_document <- function() {
   filename <- rmarkdown::draft(tempfile(fileext = ".Rmd"), edit = FALSE,
                                template="pdf_document", package = "BiocStyle")
   lines <- BiocStyle:::readUTF8(filename)
-  lines <- BiocStyle:::modifyLines(lines, from = "title:", replace = FALSE, 
+  lines <- BiocStyle:::modifyLines(lines, from = "title:", replace = FALSE,
                        insert='subtitle: "Vignette Subtitle"')
   BiocStyle:::writeUTF8(lines, filename)
   rmarkdown::render(filename)
   unlink(filename)
+}
+
+test_pdf_document_uncaptioned_table <- function() {
+  ## Regression test for https://github.com/Bioconductor/BiocStyle/issues/116
+  ##
+  ## Starting with pandoc 3.8.1, an uncaptioned table is typeset by emitting
+  ## a reference to a LaTeX counter which avoids incrementing the regular
+  ## 'table' counter. BiocStyle's frozen copy of the pandoc LaTeX template
+  ## did not define that counter, causing compilation to fail with
+  ## "! LaTeX Error: No counter '' defined." (see jgm/pandoc#11201).
+  rmd <- c(
+    '---',
+    'title: "Uncaptioned table"',
+    'output:',
+    '  BiocStyle::pdf_document:',
+    '    latex_engine: lualatex',
+    '---',
+    '',
+    'An uncaptioned Markdown pipe table, with no R code involved at all:',
+    '',
+    '| File type | Suggested function     |',
+    '| ----------| ---------------------- |',
+    '| CSV       | `readr::read_csv()`    |',
+    '| TSV       | `readr::read_tsv()`    |',
+    '| SPSS      | `haven::read_spss()`   |',
+    '| xls/xlsx  | `readxl::read_excel()` |'
+  )
+  filename <- tempfile(fileext = ".Rmd")
+  writeLines(rmd, filename)
+  output_file <- tempfile(fileext = ".pdf")
+  rmarkdown::render(filename, output_file = output_file, quiet = TRUE)
+  checkTrue(file.exists(output_file))
+  unlink(c(filename, output_file))
 }


### PR DESCRIPTION
BiocStyle::pdf_document fails on recent pandoc versions. Since pandoc 3.8.2, pandoc requires the latex template to include a counter definition that BiocStyle is missing. 

I have tested this fix with pandoc 3.1.3 (worked before and after the fix), pandoc 3.8.1 (does not work, it is a botched release superseded one week after by 3.8.2) pandoc 3.8.2 (needs this fix) and pandoc 3.10 (needs this fix).

See https://github.com/jgm/pandoc/issues/11201 for the underlying issue and https://github.com/rstudio/rticles/issues/595 for how it has been patched elsewhere.

